### PR TITLE
feat: window scroll on route change, resolves #15 problem 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ import store from './store.js';
 class MyApp extends LitElement {
   render() {
     return html`
-      div class="app-content">
+      <div class="app-content">
         <lit-route
           path="/docs"
           component="my-docs"
@@ -204,6 +204,28 @@ class MyLoading extends LitElement {
 }
 
 customElements.define('my-loading', MyLoading);
+```
+
+
+
+The window will scroll to top by default, to disable add the attribute `scrollDisable`
+
+```html
+<lit-route
+  path="/whatever"
+  component="my-whatever"
+  scrollDisable
+></lit-route>
+```
+
+To scroll to the route element on load, you can set the [scrollIntoViewOptions](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView#Example) object in the attribute `.scrollOpt`
+
+```html
+<lit-route
+  path="/whatever"
+  component="my-whatever"
+  .scrollOpt="${{behavior: 'smooth', block:'end', inline:'nearest'}}"
+></lit-route>
 ```
 
 Check a more comprehensive example in https://github.com/fernandopasik/lit-redux-router/blob/master/demo/

--- a/demo/index.html
+++ b/demo/index.html
@@ -91,6 +91,17 @@
 								display: inline-block;
 								padding: 16px;
 							}
+							.spacer {
+								height:1600px;
+							}
+
+							.scrollLink {
+								color: blue;
+							}
+
+							.scrollLink:hover {
+								color: red;
+							}
 						</style>
 						<div class="app-bar">Example App</div>
 						<nav class="nav-bar">
@@ -112,13 +123,22 @@
 							<lit-route path="/about">
 								<h1>About</h1>
 							</lit-route>
-							<lit-route path="/contact" component="my-contact"></lit-route>
+							<lit-route
+								path="/contact"
+								component="my-contact"
+								scrollDisable
+							>
+							</lit-route>
 							<lit-route
 								path="/docs"
 								component="docs-page"
 								.resolve="${() => import('./docs')}"
+								.scrollOpt="${{behavior: 'smooth', block:'end', inline:'nearest'}}"
 								loading="my-loading"
 							></lit-route>
+							<div class="spacer"></div>
+							<a href="/contact" class="scrollLink">Scroll to top instantly and switch to contact contact</a><br>
+							<a href="/docs" class="scrollLink">Scroll to top smoothly and switch to docs component</a>
 						</div>
 					`;
 				}

--- a/demo/index.html
+++ b/demo/index.html
@@ -137,7 +137,7 @@
 								loading="my-loading"
 							></lit-route>
 							<div class="spacer"></div>
-							<a href="/contact" class="scrollLink">Scroll to top instantly and switch to contact contact</a><br>
+							<a href="/contact" class="scrollLink">Scroll disabled</a><br>
 							<a href="/docs" class="scrollLink">Scroll to top smoothly and switch to docs component</a>
 						</div>
 					`;

--- a/src/__tests__/route.spec.ts
+++ b/src/__tests__/route.spec.ts
@@ -1,7 +1,7 @@
 import configureStore from 'redux-mock-store';
 import * as pwaHelpers from 'pwa-helpers';
 import { customElement } from 'lit-element';
-import connectRouter, { RouteClass as Route, spreadScrollOpt } from '../route';
+import connectRouter, { RouteClass as Route } from '../route';
 
 import * as actions from '../actions';
 import * as selectors from '../selectors';
@@ -234,10 +234,7 @@ describe('Route element', () => {
         jest.spyOn(selectors, 'isRouteActive').mockImplementationOnce(() => true);
         route.stateChanged(state);
 
-        const test = spreadScrollOpt(route.scrollOpt);
-
-        expect(test).toEqual({ behavior: 'smooth', block: 'nearest', inline: 'nearest' });
-        expect(route.scrollIntoView).toHaveBeenCalledWith(test);
+        expect(route.scrollIntoView).toHaveBeenCalledWith(route.scrollOpt);
       });
     });
 
@@ -296,7 +293,6 @@ describe('Route element', () => {
         expect(route.isResolving).toBe(true);
         const rendered = route.render();
         expect(rendered).toBe('<my-loading></my-loading>');
-        spy.mockClear();
       });
 
       test('after resolve completes', () => {

--- a/src/__tests__/route.spec.ts
+++ b/src/__tests__/route.spec.ts
@@ -35,6 +35,7 @@ jest.mock('../selectors', () => ({
 
 const mockStore = configureStore([]);
 
+
 describe('Route element', () => {
   beforeAll(() => {
     Object.defineProperty(global, 'window', {
@@ -43,6 +44,7 @@ describe('Route element', () => {
           define: jest.fn(),
         },
         decodeURIComponent: jest.fn(val => val),
+        scrollTo: jest.fn(),
       },
     });
   });
@@ -131,6 +133,7 @@ describe('Route element', () => {
       route.stateChanged(state);
 
       expect(spy).toHaveBeenCalledWith(state, path);
+      expect(window.scrollTo).toHaveBeenCalledWith(0, 0);
       expect(route.active).toBe(true);
 
       spy.mockRestore();

--- a/src/route.ts
+++ b/src/route.ts
@@ -20,11 +20,6 @@ let routerInstalled = false;
 // eslint-disable-next-line import/no-mutable-exports, @typescript-eslint/no-explicit-any
 export let RouteClass: any;
 
-interface ScrollIntoViewOptions { behavior?: string; block?: string; inline?: string }
-type DropScrollIntoViewOptions<T> = Pick<T, Exclude<keyof T, keyof ScrollIntoViewOptions>>;
-export const spreadScrollOpt = <T extends ScrollIntoViewOptions>(obj: T):
-DropScrollIntoViewOptions<T> => obj;
-
 export default (store: Store<State> & LazyStore) => {
   /**
    * Element that renders its content or a component
@@ -56,7 +51,7 @@ export default (store: Store<State> & LazyStore) => {
     private loading?: string;
 
     @property({ type: Object })
-    private scrollOpt?: ScrollIntoViewOptions = {};
+    private scrollOpt? = {};
 
     @property({ type: Boolean })
     private scrollDisable?: boolean = false;
@@ -91,7 +86,7 @@ export default (store: Store<State> & LazyStore) => {
       }
       if (this.active && !this.scrollDisable && this.scrollOpt) {
         if (Object.keys(this.scrollOpt).length !== 0) {
-          this.scrollIntoView(spreadScrollOpt(this.scrollOpt));
+          this.scrollIntoView({ ...this.scrollOpt });
         } else {
           window.scrollTo(0, 0);
         }

--- a/src/route.ts
+++ b/src/route.ts
@@ -20,6 +20,11 @@ let routerInstalled = false;
 // eslint-disable-next-line import/no-mutable-exports, @typescript-eslint/no-explicit-any
 export let RouteClass: any;
 
+interface ScrollIntoViewOptions { behavior?: string; block?: string; inline?: string }
+type DropScrollIntoViewOptions<T> = Pick<T, Exclude<keyof T, keyof ScrollIntoViewOptions>>;
+const spreadScrollOpt = <T extends ScrollIntoViewOptions>(obj: T):
+DropScrollIntoViewOptions<T> => obj;
+
 export default (store: Store<State> & LazyStore) => {
   /**
    * Element that renders its content or a component
@@ -50,6 +55,12 @@ export default (store: Store<State> & LazyStore) => {
     @property({ type: String })
     private loading?: string;
 
+    @property({ type: Object })
+    private scrollOpt?: ScrollIntoViewOptions = {};
+
+    @property({ type: Boolean })
+    private scrollDisable?: boolean = false;
+
     public firstUpdated(): void {
       if (!routerInstalled) {
         installRouter((location) => {
@@ -77,6 +88,13 @@ export default (store: Store<State> & LazyStore) => {
           .catch(() => {
             this.isResolving = false;
           });
+      }
+      if (this.active && !this.scrollDisable && this.scrollOpt) {
+        if (Object.keys(this.scrollOpt).length !== 0) {
+          this.scrollIntoView(spreadScrollOpt(this.scrollOpt));
+        } else {
+          window.scrollTo(0, 0);
+        }
       }
     }
 

--- a/src/route.ts
+++ b/src/route.ts
@@ -22,7 +22,7 @@ export let RouteClass: any;
 
 interface ScrollIntoViewOptions { behavior?: string; block?: string; inline?: string }
 type DropScrollIntoViewOptions<T> = Pick<T, Exclude<keyof T, keyof ScrollIntoViewOptions>>;
-const spreadScrollOpt = <T extends ScrollIntoViewOptions>(obj: T):
+export const spreadScrollOpt = <T extends ScrollIntoViewOptions>(obj: T):
 DropScrollIntoViewOptions<T> => obj;
 
 export default (store: Store<State> & LazyStore) => {


### PR DESCRIPTION
<!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first so it can be discussed first.**
-->

**Description**
This resolves the issue of accessibility where the window is failing to scroll to top on route change.

#### New properties
* `scrollDisable` which is a boolean toggle for disabling any form of scrolling
* `scrollOpt` which is an object

By default, without these properties the router will forcefully scroll the window to top.  You can set it using scrollOpt to force it to just the top/bottom of the route component using [scrollIntoViewOptions](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView#Example).

#### Examples:

```html
<lit-route
  path="/contact"
  component="my-contact"
  .scrollOpt="${{behavior: 'smooth', block:'start', inline:'nearest'}}"
></lit-route>
<lit-route
  path="/whatever"
  component="my-whatever"
  scrollDisable
></lit-route>
```



**Closing issues**
resolves #15 problem 2
