### PR TITLE
fix: consistent activeRoute on anchor/refresh, closes #17

### DIFF
--- a/src/__tests__/route.spec.ts
+++ b/src/__tests__/route.spec.ts
@@ -108,12 +108,13 @@ describe('Route element', () => {
       const spy2 = jest.spyOn(actions, 'setActiveRoute');
       const pathname = '/example';
       const search = '?test=testing';
+      const hash = '#example';
 
       route.firstUpdated();
       const cb = spy1.mock.results[0].value;
-      cb({ pathname, search });
+      cb({ pathname, search, hash });
 
-      expect(spy2).toHaveBeenCalledWith(pathname + search);
+      expect(spy2).toHaveBeenCalledWith(pathname + search + hash);
 
       spy1.mockRestore();
       spy2.mockRestore();

--- a/src/__tests__/route.spec.ts
+++ b/src/__tests__/route.spec.ts
@@ -107,13 +107,13 @@ describe('Route element', () => {
       const spy1 = jest.spyOn(pwaHelpers, 'installRouter');
       const spy2 = jest.spyOn(actions, 'setActiveRoute');
       const pathname = '/example';
+      const search = '?test=testing';
 
       route.firstUpdated();
-
       const cb = spy1.mock.results[0].value;
-      cb({ pathname });
+      cb({ pathname, search });
 
-      expect(spy2).toHaveBeenCalledWith(pathname);
+      expect(spy2).toHaveBeenCalledWith(pathname + search);
 
       spy1.mockRestore();
       spy2.mockRestore();

--- a/src/route.ts
+++ b/src/route.ts
@@ -58,8 +58,8 @@ export default (store: Store<State> & LazyStore) => {
 
     public firstUpdated(): void {
       if (!routerInstalled) {
-        installRouter((location) => {
-          const path = window.decodeURIComponent(location.pathname + location.search);
+        installRouter(({ pathname, search, hash }) => {
+          const path = window.decodeURIComponent(pathname + search + hash);
           return store.dispatch(setActiveRoute(path));
         });
         routerInstalled = true;

--- a/src/route.ts
+++ b/src/route.ts
@@ -59,7 +59,7 @@ export default (store: Store<State> & LazyStore) => {
     public firstUpdated(): void {
       if (!routerInstalled) {
         installRouter((location) => {
-          const path = window.decodeURIComponent(location.pathname);
+          const path = window.decodeURIComponent(location.pathname + location.search);
           return store.dispatch(setActiveRoute(path));
         });
         routerInstalled = true;


### PR DESCRIPTION
**Description**
`activeRoute` doesn't contain query params on refresh or if linked with anchor element. If however `navigate()` is used, query parameters will be within activeRoute.  Fixing to consistently include query parameters.

edit: updated test for `can set active route`  to include a query param.

**Closing issues**
Closes #17 