### PR TITLE
Nested routes

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -122,6 +122,10 @@
 							<lit-route path="/products/:id?/:name?" component="my-product"></lit-route>
 							<lit-route path="/about">
 								<h1>About</h1>
+								<a href="/about/me">Me</a>
+								<lit-route path="/me">
+									<h1>About Me</h1>
+								</lit-route>
 							</lit-route>
 							<lit-route
 								path="/contact"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "bundlesize": [
     {
       "path": "dist/lit-redux-router.min.js",
-      "maxSize": "1.5 kB"
+      "maxSize": "1.6 kB"
     }
   ],
   "dependencies": {

--- a/src/__tests__/route.spec.ts
+++ b/src/__tests__/route.spec.ts
@@ -7,7 +7,11 @@ import * as actions from '../actions';
 import * as selectors from '../selectors';
 
 jest.mock('lit-element', () => ({
-  LitElement: class LitElement {},
+  LitElement: class LitElement {
+    public querySelector() {
+      return null;
+    }
+  },
   html: jest.fn((strings, ...values) => strings
     .map((string: string, index: number) => string + (values[index] || '')).join('')),
   customElement: jest.fn(),
@@ -328,6 +332,40 @@ describe('Route element', () => {
       route.firstUpdated();
 
       expect(route).toHaveProperty('path', '/first/second');
+
+      spy.mockRestore();
+      spy2.mockRestore();
+    });
+
+    test('does not compose and return its path when no child route', () => {
+      connectRouter(mockStore({}));
+      const spy = jest.spyOn(actions, 'addRoute');
+      const route = new Route();
+      route.path = '/second';
+      route.parentElement = {};
+      route.parentElement.closest = () => {};
+      const spy2 = jest.spyOn(route.parentElement, 'closest').mockReturnValueOnce(null);
+
+      route.firstUpdated();
+
+      expect(route).toHaveProperty('path', '/second');
+
+      spy.mockRestore();
+      spy2.mockRestore();
+    });
+
+    test('parent routes match with wildcard', () => {
+      connectRouter(mockStore({}));
+      const spy = jest.spyOn(actions, 'addRoute');
+      const route = new Route();
+      route.path = '/about';
+      const childRoute = new Route();
+      childRoute.path = '/me';
+      const spy2 = jest.spyOn(route, 'querySelector').mockReturnValueOnce(childRoute);
+
+      route.firstUpdated();
+
+      expect(route).toHaveProperty('path', '/about.*');
 
       spy.mockRestore();
       spy2.mockRestore();

--- a/src/__tests__/route.spec.ts
+++ b/src/__tests__/route.spec.ts
@@ -23,11 +23,6 @@ jest.mock('pwa-helpers', () => ({
   installRouter: jest.fn(cb => cb),
 }));
 
-jest.mock('../actions', () => ({
-  setActiveRoute: jest.fn(() => ({ type: '' })),
-  addRoute: jest.fn(() => ({ type: '' })),
-}));
-
 jest.mock('../selectors', () => ({
   isRouteActive: jest.fn(() => false),
   getRouteParams: jest.fn(() => ({})),
@@ -316,6 +311,26 @@ describe('Route element', () => {
         const rendered = route.render();
         expect(rendered).toBe('<docs-page></docs-page>');
       });
+    });
+  });
+
+  describe('nested routes', () => {
+    test('composes and sets the path', () => {
+      connectRouter(mockStore({}));
+      const spy = jest.spyOn(actions, 'addRoute');
+      const route = new Route();
+      route.path = '/second';
+      route.parentElement = new Route();
+      route.parentElement.path = '/first';
+      route.parentElement.closest = () => {};
+      const spy2 = jest.spyOn(route.parentElement, 'closest').mockReturnValueOnce(route.parentElement);
+
+      route.firstUpdated();
+
+      expect(route).toHaveProperty('path', '/first/second');
+
+      spy.mockRestore();
+      spy2.mockRestore();
     });
   });
 });

--- a/src/route.ts
+++ b/src/route.ts
@@ -78,6 +78,12 @@ export default (store: Store<State> & LazyStore): void => {
         current = closestLitRoute && closestLitRoute.parentElement;
       }
 
+      const hasChildRoutes = Boolean(this.querySelector('lit-route'));
+
+      if (hasChildRoutes) {
+        path += '.*';
+      }
+
       this.path = path;
 
       if (this.path) {

--- a/src/route.ts
+++ b/src/route.ts
@@ -38,7 +38,7 @@ export default (store: Store<State> & LazyStore): void => {
     @property({ type: Object })
     private params: RouteParams = {};
 
-    @property({ type: String, reflect: true })
+    @property({ type: String })
     private path?: string;
 
     @property({ type: Boolean })

--- a/src/route.ts
+++ b/src/route.ts
@@ -38,7 +38,7 @@ export default (store: Store<State> & LazyStore): void => {
     @property({ type: Object })
     private params: RouteParams = {};
 
-    @property({ type: String })
+    @property({ type: String, reflect: true })
     private path?: string;
 
     @property({ type: Boolean })
@@ -64,6 +64,21 @@ export default (store: Store<State> & LazyStore): void => {
         });
         routerInstalled = true;
       }
+
+      let current: Route | HTMLElement | null = this.parentElement;
+      let { path } = this;
+
+      while (current) {
+        const closestLitRoute = current.closest('lit-route');
+
+        if (closestLitRoute) {
+          path = `${closestLitRoute.path}${path}`;
+        }
+
+        current = closestLitRoute && closestLitRoute.parentElement;
+      }
+
+      this.path = path;
 
       if (this.path) {
         store.dispatch(addRoute(this.path));


### PR DESCRIPTION
**Description**
A declarative way of doing nested routes by nesting `lit-route` elements with partial routes that get composed.
Work in progress on solving the issue #23 23

**Example**

```
<lit-route path="/about" component="my-about">
  <lit-route path="/me" component="my-about-me"></lit-route>
  <lit-route path="/company" component="my-about-company"></lit-route>
</lit-route>
```
Closes #23
