### PR TITLE
fix: temporary use again any for store state

### DIFF
--- a/src/lit-redux-router.ts
+++ b/src/lit-redux-router.ts
@@ -2,11 +2,10 @@ import { Store } from 'redux';
 import { LazyStore } from 'pwa-helpers/lazy-reducer-enhancer.js';
 
 import Route from './route';
-
 import reducer from './reducer';
-import { State } from './selectors';
 
-export const connectRouter = (store: Store<State> & LazyStore): void => {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const connectRouter = (store: Store<any> & LazyStore): void => {
   store.addReducers({ router: reducer });
 
   Route(store);

--- a/src/route.ts
+++ b/src/route.ts
@@ -20,7 +20,8 @@ let routerInstalled = false;
 // eslint-disable-next-line import/no-mutable-exports, @typescript-eslint/no-explicit-any
 export let RouteClass: any;
 
-export default (store: Store<State> & LazyStore): void => {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export default (store: Store<any> & LazyStore): void => {
   /**
    * Element that renders its content or a component
    * when browser route matches


### PR DESCRIPTION
**Description**
Revert to using `any` on state store type
The error thrown is described at #20 

**Closing issues**
Closes #20 .
