### PR TITLE
Fixing Hash in active route preventing route from loading

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -3,7 +3,7 @@ import { Route, RouteParams } from './reducer';
 
 export const refreshRoute = (route: string, activeRoute: string): Route => {
   const { pattern, keys } = regexparam(route);
-  const noQueryRoute = activeRoute.replace(/\?.*/, '');
+  const noQueryRoute = activeRoute.replace(/(\?|#).*/, '');
   const match = pattern.exec(noQueryRoute);
   const active = pattern.test(noQueryRoute);
 


### PR DESCRIPTION
### Description
Updated the refreshRoute's noQueryRoute regex to allow for '#' to be replaced when route refreshed.

**Closing issues**
Closes #26
