### PR TITLE
fix only scroll into view if route has become active

### DIFF
--- a/demo/app.ts
+++ b/demo/app.ts
@@ -8,9 +8,26 @@ import './product';
 
 connectRouter(store);
 
+const testReducer = (state = { test: true }, { type = '' }) => {
+  switch (type) {
+    case 'TEST_FALSE':
+      return { test: false };
+    case 'TEST_TRUE':
+      return { test: true };
+    default:
+      return state;
+  }
+};
+
+store.addReducers({ test: testReducer });
+
 class MyApp extends LitElement {
   public goToAbout(): void {
     store.dispatch(navigate('/about'));
+  }
+
+  public triggerStateChange(): void {
+    store.dispatch({ type: 'TEST_FALSE' });
   }
 
   public importDocs(): typeof import('./docs') {
@@ -105,6 +122,8 @@ class MyApp extends LitElement {
           loading="my-loading"
         ></lit-route>
         <div class="spacer"></div>
+        <button @click="${this.triggerStateChange}">trigger other state change</button>
+        <br />
         <a href="/contact" class="scrollLink">Scroll disabled</a><br />
         <a href="/docs" class="scrollLink">Scroll to top smoothly and switch to docs component</a>
       </div>

--- a/src/lib/route.ts
+++ b/src/lib/route.ts
@@ -87,7 +87,9 @@ export default (store: Store<any> & LazyStore): void => {
     }
 
     public stateChanged(state: State): void {
-      this.active = isRouteActive(state, this.path);
+      const isActive = isRouteActive(state, this.path);
+      const hasBecomeActive = !this.active && isActive;
+      this.active = isActive;
       this.params = getRouteParams(state, this.path);
 
       if (this.active && this.resolve) {
@@ -102,7 +104,9 @@ export default (store: Store<any> & LazyStore): void => {
       }
       if (this.active && !this.scrollDisable && this.scrollOpt) {
         if (Object.keys(this.scrollOpt).length !== 0) {
-          this.scrollIntoView({ ...this.scrollOpt });
+          if (hasBecomeActive) {
+            this.scrollIntoView({ ...this.scrollOpt });
+          }
         } else {
           window.scrollTo(0, 0);
         }


### PR DESCRIPTION
Closes #39 

## Description

Scroll into view was being triggered on any state change because it was not analysed if the recent state change was because of routing.