### PR TITLE
fix(router): fixes workaround introduced in issue-44

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
   "bundlesize": [
     {
       "path": "lit-redux-router.min.js",
-      "maxSize": "1.7 kB"
+      "maxSize": "1.71 kB"
     }
   ]
 }

--- a/src/lib/__tests__/route.spec.ts
+++ b/src/lib/__tests__/route.spec.ts
@@ -45,6 +45,7 @@ describe('route element', () => {
       value: {
         customElements: {
           define: jest.fn(),
+          get: jest.fn(),
         },
         decodeURIComponent: jest.fn((val) => val),
         scrollTo: jest.fn(),
@@ -260,9 +261,9 @@ describe('route element', () => {
 
         route.stateChanged(state);
 
-        expect(route.isResolving).toBe(false);
+        expect(route.isResolving).toBe(true);
         const rendered = route.render();
-        expect(rendered).toBe('<docs-page></docs-page>');
+        expect(rendered).toBe('');
       });
 
       it('after resolve completes', () => {

--- a/src/lib/__tests__/route.spec.ts
+++ b/src/lib/__tests__/route.spec.ts
@@ -56,7 +56,7 @@ describe('route element', () => {
   });
 
   beforeEach(() => {
-    customElementsGet.mockReset();
+    customElementsGet.mockClear();
   });
 
   it('defines the custom element', () => {
@@ -282,7 +282,7 @@ describe('route element', () => {
         route.path = '/';
         const state = { activeRoute: route.path };
 
-        customElementsGet.mockReturnValue(() => ({}));
+        customElementsGet.mockReturnValue({});
 
         const spy = jest.spyOn(route, 'stateChanged').mockImplementationOnce(() => true);
         route.stateChanged(state);
@@ -327,7 +327,7 @@ describe('route element', () => {
         route.path = '/';
         const state = { activeRoute: route.path };
 
-        customElementsGet.mockReturnValue(() => ({}));
+        customElementsGet.mockReturnValue({});
 
         const spy = jest.spyOn(route, 'stateChanged').mockImplementationOnce(() => true);
         route.stateChanged(state);
@@ -345,8 +345,9 @@ describe('route element', () => {
         route.resolve = async (): Promise<void> => Promise.reject();
         route.loading = 'my-loading';
         route.path = '/';
-
         const state = { activeRoute: route.path };
+
+        customElementsGet.mockReturnValue(undefined);
 
         const spy = jest.spyOn(selectors, 'isRouteActive').mockImplementationOnce(() => true);
 

--- a/src/lib/__tests__/route.spec.ts
+++ b/src/lib/__tests__/route.spec.ts
@@ -40,17 +40,23 @@ jest.mock('../selectors', () => ({
 const mockStore = configureStore([]);
 
 describe('route element', () => {
+  const customElementsGet = jest.fn();
+
   beforeAll(() => {
     Object.defineProperty(global, 'window', {
       value: {
         customElements: {
           define: jest.fn(),
-          get: jest.fn(),
+          get: customElementsGet,
         },
         decodeURIComponent: jest.fn((val) => val),
         scrollTo: jest.fn(),
       },
     });
+  });
+
+  beforeEach(() => {
+    customElementsGet.mockReset();
   });
 
   it('defines the custom element', () => {
@@ -257,6 +263,8 @@ describe('route element', () => {
         route.path = '/';
         const state = { activeRoute: route.path };
 
+        customElementsGet.mockReturnValue(undefined);
+
         jest.spyOn(selectors, 'isRouteActive').mockImplementationOnce(() => true);
 
         route.stateChanged(state);
@@ -273,6 +281,9 @@ describe('route element', () => {
         route.resolve = importFile;
         route.path = '/';
         const state = { activeRoute: route.path };
+
+        customElementsGet.mockReturnValue(() => ({}));
+
         const spy = jest.spyOn(route, 'stateChanged').mockImplementationOnce(() => true);
         route.stateChanged(state);
 
@@ -293,8 +304,9 @@ describe('route element', () => {
         route.resolve = importFile;
         route.loading = 'my-loading';
         route.path = '/';
-
         const state = { activeRoute: route.path };
+
+        customElementsGet.mockReturnValue(undefined);
 
         const spy = jest.spyOn(selectors, 'isRouteActive').mockImplementationOnce(() => true);
 
@@ -313,8 +325,10 @@ describe('route element', () => {
         route.resolve = importFile;
         route.loading = 'my-loading';
         route.path = '/';
-
         const state = { activeRoute: route.path };
+
+        customElementsGet.mockReturnValue(() => ({}));
+
         const spy = jest.spyOn(route, 'stateChanged').mockImplementationOnce(() => true);
         route.stateChanged(state);
 

--- a/src/lib/__tests__/route.spec.ts
+++ b/src/lib/__tests__/route.spec.ts
@@ -284,10 +284,9 @@ describe('route element', () => {
 
         customElementsGet.mockReturnValue({});
 
-        const spy = jest.spyOn(route, 'stateChanged').mockImplementationOnce(() => true);
+        jest.spyOn(selectors, 'isRouteActive').mockImplementationOnce(() => true);
         route.stateChanged(state);
 
-        expect(spy).toHaveBeenCalledWith(state);
         expect(route.isResolving).toBe(false);
         const rendered = route.render();
         expect(rendered).toBe('<docs-page></docs-page>');
@@ -309,7 +308,6 @@ describe('route element', () => {
         customElementsGet.mockReturnValue(undefined);
 
         const spy = jest.spyOn(selectors, 'isRouteActive').mockImplementationOnce(() => true);
-
         route.stateChanged(state);
 
         expect(spy).toHaveBeenCalledWith(state, route.path);
@@ -329,10 +327,10 @@ describe('route element', () => {
 
         customElementsGet.mockReturnValue({});
 
-        const spy = jest.spyOn(route, 'stateChanged').mockImplementationOnce(() => true);
+        const spy = jest.spyOn(selectors, 'isRouteActive').mockImplementationOnce(() => true);
         route.stateChanged(state);
 
-        expect(spy).toHaveBeenCalledWith(state);
+        expect(spy).toHaveBeenCalledWith(state, route.path);
         expect(route.isResolving).toBe(false);
         const rendered = route.render();
         expect(rendered).toBe('<docs-page></docs-page>');
@@ -350,7 +348,6 @@ describe('route element', () => {
         customElementsGet.mockReturnValue(undefined);
 
         const spy = jest.spyOn(selectors, 'isRouteActive').mockImplementationOnce(() => true);
-
         route.stateChanged(state);
 
         expect(spy).toHaveBeenCalledWith(state, route.path);
@@ -368,10 +365,13 @@ describe('route element', () => {
         route.path = '/';
 
         const state = { activeRoute: route.path };
-        const spy = jest.spyOn(route, 'stateChanged').mockImplementationOnce(() => true);
+
+        customElementsGet.mockReturnValue({});
+
+        const spy = jest.spyOn(selectors, 'isRouteActive').mockImplementationOnce(() => true);
         route.stateChanged(state);
 
-        expect(spy).toHaveBeenCalledWith(state);
+        expect(spy).toHaveBeenCalledWith(state, route.path);
         expect(route.isResolving).toBe(false);
         const rendered = route.render();
         expect(rendered).toBe('<docs-page></docs-page>');

--- a/src/lib/route.ts
+++ b/src/lib/route.ts
@@ -56,9 +56,15 @@ export default (store: Readonly<Store & LazyStore>): void => {
     @property({ type: Boolean })
     public scrollDisable: boolean = false;
 
-    private setIsResolving(isResolving: boolean): void {
-      if (this.loading) {
-        this.isResolving = isResolving;
+    private setResolving(): void {
+      if (this.component && !window.customElements.get(this.component)) {
+        this.isResolving = true;
+      }
+    }
+
+    private unsetResolving(): void {
+      if (this.component && window.customElements.get(this.component)) {
+        this.isResolving = false;
       }
     }
 
@@ -104,13 +110,13 @@ export default (store: Readonly<Store & LazyStore>): void => {
       this.params = getRouteParams(state, this.path);
 
       if (this.active && this.resolve) {
-        this.setIsResolving(true);
+        this.setResolving();
         this.resolve()
           .then((): void => {
-            this.setIsResolving(false);
+            this.unsetResolving();
           })
           .catch((): void => {
-            this.setIsResolving(false);
+            this.unsetResolving();
           });
       }
       if (this.active && !this.scrollDisable) {


### PR DESCRIPTION
When using a loading component, the unneccesary state change was not fixed. This does not rely on the loading
component. Only change resolving, when there is something to resolve.

This reverts the changes in the test and restores the behavior from 0.15.3.

If you like, you can include. This seems a far better solution than the one before.
I could think also of a short cut, which tests only the isResolving variable first.