### PR TITLE
Fix broken lazy loading

### DIFF
--- a/demo/app.ts
+++ b/demo/app.ts
@@ -121,7 +121,7 @@ class MyApp extends LitElement {
             <h1>About Me</h1>
           </lit-route>
         </lit-route>
-        <lit-route path="/contact" component="my-contact" scrollDisable> </lit-route>
+        <lit-route path="/contact" component="my-contact" scrollDisable></lit-route>
         <lit-route
           path="/docs"
           component="docs-page"

--- a/demo/app.ts
+++ b/demo/app.ts
@@ -42,6 +42,10 @@ class MyApp extends LitElement {
     store.dispatch({ type: 'TEST_FALSE' });
   }
 
+  public async importDocs(): Promise<void> {
+    await import('./docs');
+  }
+
   public render(): TemplateResult {
     return html`
       <style>
@@ -125,7 +129,7 @@ class MyApp extends LitElement {
         <lit-route
           path="/docs"
           component="docs-page"
-          .resolve="${import('./docs')}"
+          .resolve="${this.importDocs}"
           .scrollOpt="${{ behavior: 'smooth', block: 'end', inline: 'nearest' }}"
           loading="my-loading"
         ></lit-route>

--- a/src/lib/route.ts
+++ b/src/lib/route.ts
@@ -158,7 +158,7 @@ export default (store: Readonly<LazyStore & Store>): void => {
     private unsetResolving(): void {
       if (
         typeof this.component !== 'undefined' &&
-        typeof window.customElements.get(this.component) === 'undefined'
+        typeof window.customElements.get(this.component) !== 'undefined'
       ) {
         this.isResolving = false;
       }


### PR DESCRIPTION
Closes #51.

## Description

Resolving needs to be considered done once
the element is defined, not if the element
is undefined. This is a typo introduced in
41b69c718.
   
Also adapt the demo to use real lazy loading again.
The usage of `.route="${import(…)}"` means the component
is loaded by the time the `<lit-route>` is rendered,
not when the route actually becomes active.


